### PR TITLE
fix issue 4 - show conned wallet infos

### DIFF
--- a/packages/nextjs/components/ConnectedWalletBatchInfos.tsx
+++ b/packages/nextjs/components/ConnectedWalletBatchInfos.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import { useAccount } from "wagmi";
+import { AcademicCapIcon, CheckBadgeIcon } from "@heroicons/react/24/outline";
+import { useScaffoldReadContract } from "~~/hooks/scaffold-eth";
+
+export const ConnectedWalletBatchInfos = () => {
+  const { address } = useAccount();
+  const isMember = useScaffoldReadContract({
+    contractName: "BatchRegistry",
+    functionName: "allowList",
+    args: [address],
+  });
+  const userContractAddress = useScaffoldReadContract({
+    contractName: "BatchRegistry",
+    functionName: "yourContractAddress",
+    args: [address],
+  });
+
+  const isCheckedIn =
+    typeof userContractAddress.data === "string" &&
+    userContractAddress.data !== "0x0000000000000000000000000000000000000000";
+
+  return (
+    <div className="flex gap-2">
+      {isMember.data && <AcademicCapIcon className="size-6" title="Batch Member" />}
+      {isCheckedIn && <CheckBadgeIcon className="size-6" title="Checked In" />}
+    </div>
+  );
+};

--- a/packages/nextjs/components/Header.tsx
+++ b/packages/nextjs/components/Header.tsx
@@ -4,6 +4,7 @@ import React, { useRef } from "react";
 import Image from "next/image";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
+import { ConnectedWalletBatchInfos } from "./ConnectedWalletBatchInfos";
 import { hardhat } from "viem/chains";
 import { Bars3Icon, BugAntIcon } from "@heroicons/react/24/outline";
 import { FaucetButton, RainbowKitCustomConnectButton } from "~~/components/scaffold-eth";
@@ -96,6 +97,7 @@ export const Header = () => {
         </ul>
       </div>
       <div className="navbar-end grow mr-4">
+        <ConnectedWalletBatchInfos />
         <RainbowKitCustomConnectButton />
         {isLocalNetwork && <FaucetButton />}
       </div>


### PR DESCRIPTION
## Description

Added 2 icones in the header 1 showing if the connected user is a member and an other to show if the user has checked in.

## Additional Information

- [ ] I have read the [contributing docs](/scaffold-eth/scaffold-eth-2/blob/main/CONTRIBUTING.md) (if this is your first contribution)
- [ ] This is not a duplicate of any [existing pull request](https://github.com/scaffold-eth/scaffold-eth-2/pulls)

## Related Issues

_Closes #4 

_Note: If your changes are small and straightforward, you may skip the creation of an issue beforehand and remove this section. However, for medium-to-large changes, it is recommended to have an open issue for discussion and approval prior to submitting a pull request._
<img width="753" height="1911" alt="Capture d'écran 2025-08-18 192928" src="https://github.com/user-attachments/assets/30aa0251-3c23-48de-8c9f-a1884d70f124" />
<img width="3044" height="1912" alt="Capture d'écran 2025-08-18 192852" src="https://github.com/user-attachments/assets/23949c21-6ed6-4ac5-b192-e1a799a9f68d" />

Your ENS/address:
cmaranber.eth
